### PR TITLE
am43: add invert_position option to am43 covers

### DIFF
--- a/esphome/components/am43/cover/__init__.py
+++ b/esphome/components/am43/cover/__init__.py
@@ -7,6 +7,8 @@ CODEOWNERS = ["@buxtronix"]
 DEPENDENCIES = ["ble_client"]
 AUTO_LOAD = ["am43"]
 
+CONF_INVERT_POSITION = "invert_position"
+
 am43_ns = cg.esphome_ns.namespace("am43")
 Am43Component = am43_ns.class_(
     "Am43Component", cover.Cover, ble_client.BLEClientNode, cg.Component
@@ -17,6 +19,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(Am43Component),
             cv.Optional(CONF_PIN, default=8888): cv.int_range(min=0, max=0xFFFF),
+            cv.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
         }
     )
     .extend(ble_client.BLE_CLIENT_SCHEMA)
@@ -27,6 +30,7 @@ CONFIG_SCHEMA = (
 def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_pin(config[CONF_PIN]))
+    cg.add(var.set_invert_position(config[CONF_INVERT_POSITION]))
     yield cg.register_component(var, config)
     yield cover.register_cover(var, config)
     yield ble_client.register_ble_node(var, config)

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -108,8 +108,8 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
 
       if (this->decoder_->has_position()) {
 
-        this->position = 1 - ((float) this->decoder_->position_ / 100.0);
-        if (this->invert_position_)
+        this->position = ((float) this->decoder_->position_ / 100.0);
+        if (!this->invert_position_)
           this->position = 1 - this->position;
         if (this->position > 0.97)
           this->position = 1.0;

--- a/esphome/components/am43/cover/am43_cover.cpp
+++ b/esphome/components/am43/cover/am43_cover.cpp
@@ -13,6 +13,7 @@ using namespace esphome::cover;
 void Am43Component::dump_config() {
   LOG_COVER("", "AM43 Cover", this);
   ESP_LOGCONFIG(TAG, "  Device Pin: %d", this->pin_);
+  ESP_LOGCONFIG(TAG, "  Invert Position: %d", (int) this->invert_position_);
 }
 
 void Am43Component::setup() {
@@ -59,6 +60,9 @@ void Am43Component::control(const CoverCall &call) {
   }
   if (call.get_position().has_value()) {
     auto pos = *call.get_position();
+
+    if (this->invert_position_)
+      pos = 1 - pos;
     auto packet = this->encoder_->get_set_position_request(100 - (uint8_t)(pos * 100));
     auto status =
         esp_ble_gattc_write_char(this->parent_->gattc_if, this->parent_->conn_id, this->char_handle_, packet->length,
@@ -103,7 +107,10 @@ void Am43Component::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->decoder_->decode(param->notify.value, param->notify.value_len);
 
       if (this->decoder_->has_position()) {
+
         this->position = 1 - ((float) this->decoder_->position_ / 100.0);
+        if (this->invert_position_)
+          this->position = 1 - this->position;
         if (this->position > 0.97)
           this->position = 1.0;
         if (this->position < 0.02)

--- a/esphome/components/am43/cover/am43_cover.h
+++ b/esphome/components/am43/cover/am43_cover.h
@@ -25,11 +25,13 @@ class Am43Component : public cover::Cover, public esphome::ble_client::BLEClient
   float get_setup_priority() const override { return setup_priority::DATA; }
   cover::CoverTraits get_traits() override;
   void set_pin(uint16_t pin) { this->pin_ = pin; }
+  void set_invert_position(bool invert_position) { this->invert_position_ = invert_position; }
 
  protected:
   void control(const cover::CoverCall &call) override;
   uint16_t char_handle_;
   uint16_t pin_;
+  bool invert_position_;
   Am43Encoder *encoder_;
   Am43Decoder *decoder_;
   bool logged_in_;


### PR DESCRIPTION
# What does this implement/fix? 

This adds an invert_position option to the am43 based covers, as one of my curtains is open at 0 and closed at 100%. Checking the OpenHAB implementation, it has this option for the same purpose.

https://www.openhab.org/addons/bindings/bluetooth.am43/

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

Documentation is not yet available, am43 is not yet merged either. I'd like to solicitate feedback first.
esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP8266

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
  - platform: am43
    device_class: curtain
    name: "Nappali Ablak jobb oldal"
    id: nappali2_cover
    pin: "8888"
    invert_position: True
    ble_client_id: nappali2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
